### PR TITLE
Zugelman patch 1 1

### DIFF
--- a/gramjs/client/uploads.ts
+++ b/gramjs/client/uploads.ts
@@ -502,6 +502,7 @@ export async function _sendAlbum(
     {
         file,
         caption,
+        formattingEntities,
         forceDocument = false,
         fileSize,
         clearDraft = false,
@@ -535,8 +536,15 @@ export async function _sendAlbum(
         caption = [caption];
     }
     const captions: [string, Api.TypeMessageEntity[]][] = [];
+    let counter = 0;
     for (const c of caption) {
-        captions.push(await _parseMessageText(client, c, parseMode));
+        if (!formattingEntities?.length){
+            captions.push(await _parseMessageText(client, c, parseMode));
+        }
+        else {
+            captions.push([c, counter?[]:formattingEntities]);
+        }
+        counter++;
     }
     if (commentTo != undefined) {
         const discussionData = await getCommentData(client, entity, commentTo);

--- a/gramjs/client/uploads.ts
+++ b/gramjs/client/uploads.ts
@@ -680,6 +680,7 @@ export async function sendFile(
         return await _sendAlbum(client, entity, {
             file: file,
             caption: caption,
+            formattingEntities: formattingEntities,
             replyTo: replyTo,
             parseMode: parseMode,
             attributes: attributes,


### PR DESCRIPTION
If you send multiple images with formattingEntities, formatting will not be applied.
Therefore, I added formattingEntities and processed the condition if there are formattingEntities, then we use it, if not, then parseMod